### PR TITLE
Stop-gap frontend fixes

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -25,48 +25,24 @@ Body {
 }
 
 .guest-beers {
-  width: 838px;
-  height: 90px;
-  float: right;
-}
-
-.guest-beers-total {
-  width: 300px;
-  float: right;
-  margin-bottom: 5px;
-  margin-right: 30px;
-}
-
-.guest-beer-name{
   font-family: RobotoSlab;
-  font-size: 18px;
+  font-size: 28px;
   font-weight: bold;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: 1.6px;
-  color: #233746;
-  float: left;
+  margin-left: auto;
+  margin-right: auto;
+  width: 1740px;
 }
 
-.guest-beer-price {
-  font-family: RobotoSlab;
-  font-size: 18px;
-  font-weight: bold;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: normal;
-  letter-spacing: 2.7px;
-  text-align: center;
-  color: #233746;
-  float: right;
+.guest-beers table {
+  background-color: white;
+  padding-left: 36px;
+  padding-bottom: 10px;
+  width: 100%;
 }
 
 .Guest-Beer {
-  width: 281px;
-  height: 90px;
+  width: 20%;
   object-fit: contain;
-  float: left;
 }
 
 .Line {
@@ -187,17 +163,16 @@ Body {
 }
 
 .tier-pricing {
-  margin-left: 20px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 1740px;
 }
 
 .tier {
+  margin-left: 36px;
   margin-top: 10px;
-  width: 868px;
+  width: 832px;
   float: left;
-}
-
-.tier:last-child {
-  margin-left: 35px;
 }
 
 .tier-main-name {

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -19,17 +19,20 @@
     </div>
   <% end %>
   </div>
-  <div class="guest-beers">
-    <% unless @guest_beers.empty? %>
-      <%= image_tag('wine-cider.svg', class:"Guest-Beer") %>
-      <% @guest_beers.each do |guest_beer|%>
-        <div class="guest-beers-total">
-          <div class="guest-beer-name"><%= guest_beer.name.upcase %></div>
-          <div class="guest-beer-price">$<%= guest_beer.price %></div>
-        </div>
+</div>
+<div class="guest-beers">
+  <% unless @guest_beers.empty? %>
+    <table>
+      <tr>
+        <td class="Guest-Beer"><%= image_tag('wine-cider.svg') %></td>
+        <% width = 80 / @guest_beers.count %>
+        <% @guest_beers.each do |guest_beer|%>
+          <td width="<%= width - 5%>%"><%= guest_beer.name %></td>
+          <td width="5%">$<%= guest_beer.price %></td>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+      </tr>
+    </table>
 </div>
 <div class="tier-pricing">
   <% @tiers.each do |tier| %>


### PR DESCRIPTION
Allow FE to show 12 beers at a time, with guest beers and tier
information.

There are 12 taps at ENBW and with a 12th beer on tap, plus the guest beers, the layout is broken. This is a stop-gap solution to make the existing CSS support a 12th beer.

The FE should still be rewritten to be responsive so that N beers can be on tap and fill up the available display space.